### PR TITLE
Correct build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "./src/lib.rs"
 [dependencies]
 aes = "0.8"
 base64 = { version = "0.13", default-features = false, features = ["alloc"] }
-bincode = { version = "2.0.0-rc.1", default-features = false, features = ["alloc", "derive"] }
+bincode = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "derive"] }
 crossterm = { version = "0.19", optional = true }
 hmac = "0.12.1"
 pbkdf2 = { version = "0.11.0", default_features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ impl LuksHeader {
     ///
     /// Note: a LUKS2 header is always exactly 4096 bytes long.
     pub fn from_slice(slice: &[u8]) -> Result<Self, ParseError> {
-        let options = bincode::config::legacy().with_big_endian().with_fixed_int_encoding().skip_fixed_array_length();
+        let options = bincode::config::legacy().with_big_endian().with_fixed_int_encoding();
         let h: Self = bincode::decode_from_slice(slice, options)?.0;
         // let h: BorrowCompat<Self> = bincode::decode_from_slice(slice, options)?.0;
         // let h = h.0;
@@ -951,10 +951,8 @@ impl<T: Read + Seek> LuksDevice<T> {
             }
             x => return Err(LuksError::UnsupportedKeySize(x)),
         }
-
         // make k a secret after decryption
         let k = Secret::new(k);
-
         // merge and hash master key
         let master_key = Secret::new(MasterKey(af::merge(
             &k.expose_secret(),


### PR DESCRIPTION
Remove the call to `skip_fixed_array_length` since it has have been removed from bincode: https://github.com/bincode-org/bincode/pull/625. It allows the project to build. This corrects #1.